### PR TITLE
chore: sync proto sagehub v1.237.0

### DIFF
--- a/proto/shopcloud/sagehub/v1/sagehub.proto
+++ b/proto/shopcloud/sagehub/v1/sagehub.proto
@@ -288,6 +288,7 @@ service SageHubService {
 
     // VKBelege
     rpc ListVKBelegs(ListVKBelegsRequest) returns (ListVKBelegsResponse);
+    rpc ListVKBelegDuplicated(ListVKBelegDuplicatedRequest) returns (ListVKBelegDuplicatedResponse);
     rpc ListVKBelegsByArticle(ListVKBelegsByArticleRequest) returns (ListVKBelegsByArticleResponse);
     rpc GetVKBelegV2(GetVKBelegV2Request) returns (GetVKBelegV2Response);
     rpc ListVKBelegSalechannels(ListVKBelegSalechannelsRequest) returns (ListVKBelegSalechannelsResponse);
@@ -4754,4 +4755,29 @@ message TransformBelegByDocumentNumberResponse {
     bool            is_success          = 1;
     string          new_document_number = 2;
     repeated string error_messages      = 3;
+}
+
+message ListVKBelegDuplicatedRequest {
+    int32  page           = 1;
+    int32  page_size      = 2;
+    int32  mandant        = 3;
+    string query          = 4;  // Advanced query filter (mandant, vorid, belegart, referenznummer)
+    int32  months_back    = 5;  // How many months back to look, default 6
+    bool   debug          = 6;
+}
+
+message VKBelegDuplicatedItem {
+    int32  mandant                      = 1;
+    int64  vor_id                       = 2;
+    string belegart                     = 3;
+    int32  total                        = 4;  // Number of duplicate documents
+    string referenznummer               = 5;
+    google.protobuf.Timestamp created_at = 6;
+}
+
+message ListVKBelegDuplicatedResponse {
+    int32                        page      = 1;
+    int32                        page_size = 2;
+    repeated VKBelegDuplicatedItem items   = 3;
+    repeated string              queries   = 4;
 }


### PR DESCRIPTION
## Proto Sync: SageHub v1.237.0

Synchronisiert die aktualisierte `.proto`-Datei von SageHub nach dem Release v1.237.0.

### Proto-Änderungen

Die folgenden neuen gRPC-Endpoints wurden aus SageHub v1.237.0 übernommen:

- `ListVKBelegDuplicated` — Duplikate VK-Belege (Talk-Point/IT#15084)
- `ListVKBelegarten` — Verfügbare Belegarten aus SAGE (Talk-Point/IT#15035)
- `TransformBelegByDocumentNumber` — Beleg transformieren via SAGE API (Talk-Point/IT#15035)
- `GetArticleStockV2` — Erweiterter Lagerbestand mit `dispo_min_belegdatum` (Talk-Point/IT#15046)
- `ListArticleDispoEntries` — Alle Dispo-Einträge eines Artikels (Talk-Point/IT#15046)
- `ListDispoBlocked` — Blockierte Dispo-Einträge > X Tage (Talk-Point/IT#15047)
- `CreateAmazonItem` — Amazon-Artikel anlegen in LBAmazonItems (Talk-Point/IT#14737)
- `SearchVKBelegPublic` — VK-Belege für Retouren-Portal suchen
- `AnalyzeEKBelegSales` — EK-Beleg-Analyse über Seriennummern
- `ListFotolagerReturnArticles` — Rückführbare Fotolager-Artikel

### Referenzen

🔗 SageHub Release PR: Talk-Point/sagehub#646  
📦 Version: v1.237.0

**Verknüpfte IT-Issues:**
- Talk-Point/IT#15084
- Talk-Point/IT#15035
- Talk-Point/IT#15046
- Talk-Point/IT#15047
- Talk-Point/IT#14737