### PR TITLE
chore: sync proto sagehub v1.251.0

### DIFF
--- a/proto/shopcloud/sagehub/v1/sagehub.proto
+++ b/proto/shopcloud/sagehub/v1/sagehub.proto
@@ -5039,6 +5039,7 @@ message CreateEbayItemRequest {
     string energy_efficiency_image_description       = 31;
     string energy_efficiency_image_url               = 32;
     string energy_efficiency_product_informationsheet = 33;
+    string photo_url                                 = 36;
     string photo_url2                                = 34;
     string photo_url3                                = 35;
 }


### PR DESCRIPTION
## Proto-Sync: SageHub v1.251.0

Übernimmt die Proto-Änderungen aus dem SageHub v1.251.0 Bug-Release.

### Änderungen

| Service | Änderung |
|---------|----------|
| `CreateEbayItemRequest` | Neues optionales Feld `photo_url` (field 36) — ermöglicht das Übergeben einer eigenen Bild-URL für Slot 1 |

### Hintergrund

In SageHub v1.251.0 wurden 4 Bugs in `CreateEbayItem` behoben (Talk-Point/IT#14580). Das Proto-Feld `photo_url` war bisher nicht vorhanden, weshalb die URL für das erste Artikelbild immer automatisch als `<artnr>_<ausp>_1.jpg` berechnet wurde — auch wenn ein anderer Wert übergeben wurde.

### Linked Issues
- Talk-Point/IT#14580

---
🔗 SageHub PR: Talk-Point/sagehub#682
📦 SageHub Version: v1.251.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)