### PR TITLE
chore: sync proto sagehub v1.255.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,7 +35,7 @@ jobs:
 
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache

--- a/proto/shopcloud/sagehub/v1/sagehub.proto
+++ b/proto/shopcloud/sagehub/v1/sagehub.proto
@@ -923,6 +923,24 @@ message UpdateAmazonItemRequest {
     UpdateMask update_mask = 4;
     bool aktiv = 5;
     bool offer_only = 6;
+
+    // Neue Felder, freigeschaltet via IT #15434 (GRANT UPDATE auf LBAmazonItems).
+    string sub_title = 7;
+    string condition_id = 8;
+    string sku = 9;
+    string memo = 10;
+    string marketplace_id = 11;
+    int32 seller_id = 12;
+    bool listing_aktiv = 13;
+    string condition_note = 14;
+    double listing_price = 15;
+    int32 min_listing_quantity = 16;
+    int32 max_listing_quantity = 17;
+    bool check_dispo = 18;
+    string product_id = 19;
+    string product_id_type = 20;
+    double business_price = 21;
+    string product_type = 22;
 }
 
 message UpdateAmazonItemResponse {


### PR DESCRIPTION
## Proto-Sync: SageHub v1.255.0

Übernimmt die Proto-Änderungen aus dem SageHub-Release v1.255.0.

### Übernommene Änderungen

`UpdateAmazonItemRequest` um 16 neue Felder erweitert (Felder 7–22, rein additiv): `sub_title`, `condition_id`, `sku`, `memo`, `marketplace_id`, `seller_id`, `listing_aktiv`, `condition_note`, `listing_price`, `min_listing_quantity`, `max_listing_quantity`, `check_dispo`, `product_id`, `product_id_type`, `business_price`, `product_type`.

Hintergrund: Freischaltung von `GRANT UPDATE` auf `LBAmazonItems`-Spalten für die Amazon-Listing-Pflege. Kein Breaking Change.

🔗 SageHub Release-PR: Talk-Point/sagehub#699
🔗 SageHub Feature-PR: Talk-Point/sagehub#698
📦 Version: v1.255.0

**Verlinkte Issues:** Talk-Point/IT#15434