### PR TITLE
chore: sync proto sagehub v1.258.0

### DIFF
--- a/proto/shopcloud/sagehub/v1/sagehub.proto
+++ b/proto/shopcloud/sagehub/v1/sagehub.proto
@@ -2248,6 +2248,9 @@ message GetArticleImageRequest {
     int32 mandant = 1;
     string artikelnummer = 2;
     int32 auspraegung_id = 3;
+    // Optional. Sprache der Bildzeile (LBSysArtikelOnlinebezeichnung ist je Sprache getrennt).
+    // Leer = Default 'D' (Pflege-Sprache, symmetrisch zum Write-Pfad). IT#15788.
+    string sprache = 4;
 }
 
 message GetArticleImageResponse {


### PR DESCRIPTION
## Proto-Sync: SageHub v1.258.0

Übernimmt die Proto-Änderung aus dem SageHub-Release v1.258.0.

### Übernommene Änderung
- `GetArticleImageRequest`: neues optionales Feld `string sprache = 4`.
  Ermöglicht das sprachspezifische Lesen von Artikel-Bildern; leer ⇒ serverseitiger Default `'D'`. Kein Breaking Change.

### Kontext
Behebt IT#15788 (Bilder von Varianten-Artikeln wurden im Editor nicht angezeigt). Der Lesepfad `GetArticleImage` filtert nun nach Sprache.

🔗 SageHub Release-PR: Talk-Point/sagehub#705
🔗 SageHub Fix-PR: Talk-Point/sagehub#704

**Verlinkte Issues:**
- Talk-Point/IT#15788