### PR TITLE
ci: Go 1.26 (Workflows + go.mod)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: [ '1.22' ]
+        go-version: [ '1.26' ]
     steps:
       - uses: actions/checkout@v6
       - name: Setup Go ${{ matrix.go-version }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Talk-Point/shopcloud
 
-go 1.22.2
+go 1.26
 
 require (
 	connectrpc.com/connect v1.16.0


### PR DESCRIPTION
Hebt die Go-Version auf 1.26 an: `go-version` in den Actions-Workflows und die `go`-Direktive in jeder go.mod (`toolchain`-Pin entfernt). Kein `go mod tidy`. Org-weite Angleichung, Tracking: Talk-Point/IT#15822.