### PR TITLE
Go 1.26 Promote nach master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: [ '1.22' ]
+        go-version: [ '1.26' ]
     steps:
       - uses: actions/checkout@v6
       - name: Setup Go ${{ matrix.go-version }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Talk-Point/shopcloud
 
-go 1.22.2
+go 1.26
 
 require (
 	connectrpc.com/connect v1.16.0


### PR DESCRIPTION
Promotet den Go-1.26-Stand von develop nach master (2 Commits ahead: Go-Bump + ggf. angestaute Security-Patches). develop ist CI-grün. Merge triggert die CD/Live-Deploys.

Schließt für dieses Repo die letzte Lücke des org-weiten Go-1.26-Upgrades (Live/master lag noch unter 1.26, wodurch auch der nächtliche Dependency-Updates-Workflow failte).

Refs: Talk-Point/IT#15822